### PR TITLE
feat: Add basic topic test

### DIFF
--- a/aplt/client.py
+++ b/aplt/client.py
@@ -184,7 +184,7 @@ class CommandProcessor(object, policies.TimeoutMixin):
         """Send a notification to the given endpoint URL"""
         self._harness.send_notification(self, url=command.endpoint_url,
                                         data=command.data,
-                                        ttl=command.ttl,
+                                        headers=command.headers,
                                         claims=command.claims)
 
     def expect_notification(self, command):

--- a/aplt/commands.py
+++ b/aplt/commands.py
@@ -34,12 +34,12 @@ class unregister(namedtuple("UnRegister", "channel_id")):
 
 
 class send_notification(namedtuple("SendNotification",
-                                   "endpoint_url data ttl claims")):
+                                   "endpoint_url data headers claims")):
     pass
 
 
 # set defaults so that we can have the claims be optional.
-send_notification.__new__.__defaults__ = (None, None, 0, None)
+send_notification.__new__.__defaults__ = (None, None, None, None)
 
 
 class expect_notification(namedtuple("ExpectNotification", "channel_id time")):

--- a/aplt/runner.py
+++ b/aplt/runner.py
@@ -122,14 +122,18 @@ class RunnerHarness(object):
         self._connect_waiters.append(processor)
         connectWS(self._factory, contextFactory=self._factory_context)
 
-    def send_notification(self, processor, url, data, ttl, claims=None):
+    def send_notification(self, processor, url, data, headers=None,
+                          claims=None):
         """Send out a notification to a url for a processor
 
         This uses the older `aesgcm` format.
 
         """
+        if not headers:
+            headers = {}
         url = url.encode("utf-8")
-        headers = {"TTL": str(ttl)}
+        if "TTL" not in headers:
+            headers["TTL"] = "0"
         crypto_key = self._crypto_key
         if claims is None:
             claims = ()

--- a/aplt/tests/__init__.py
+++ b/aplt/tests/__init__.py
@@ -85,6 +85,38 @@ class TestIntegration(unittest.TestCase):
         d.addCallback(check_log)
         return d
 
+    def test_basic_topic_runner(self):
+        """Test the "basic with topic" scenario.
+
+        This can be called via pytest using
+        `bin/pytest aplt/tests/__init__.py::TestIntegration::test_basic_runner`
+
+        Use `check_log` to examine the produced log file for whatever values
+        you need.
+
+        """  # pragma noqa
+        import aplt.runner as runner
+        h = runner.run_scenario([
+            "--log_format=json",
+            "--log_output=buffer",  # send the output to a string buffer
+            "--websocket_url={}".format(AUTOPUSH_SERVER),
+            "aplt.scenarios:basic_topic",
+        ], run=False)
+
+        def check_log(success):
+            """Check the captured output log for whatever content your
+            looking for
+
+            """
+            dump = h.logging.dump()
+            assert len(dump) > 0
+            # Additional checks here...
+
+        d = Deferred()
+        reactor.callLater(0, self._check_testplan_done, h, d)
+        d.addCallback(check_log)
+        return d
+
     def test_basic_with_vapid(self):
         import aplt.runner as runner
         h = runner.run_scenario([


### PR DESCRIPTION
*Note* this replaces the `ttl` argument for `send_notification` with
a `headers` argument that takes a dictionary of header values. Code
and tests have been modified to pass ```... header={"TTL": "60"}, ...```
where appropriate.

Closes #74